### PR TITLE
- Fix `SyntaxError: Cannot use import statement outside a module`  (Required pre-merger production testing and possible fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 yarn.lock
 pnpm-lock.yaml
+package-lock.json

--- a/nodes.json
+++ b/nodes.json
@@ -18,15 +18,6 @@
         "authorId": "612666923502796818"
     },
     {
-        "identifier": "Elf Lights.out.",
-        "host": "lavalink3.theelf.tech",
-        "port": 50050,
-        "password": "discord.gg/PqVQgXTweC",
-        "secure": false,
-        "restVersion": "v3",
-        "authorId": "612666923502796818"
-    },
-    {
         "identifier": "MYHM.Space",
         "host": "ll3.myhm.space",
         "port": 443,

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "A list of free and available public Lavalink nodes with their live status. Feel free to make a pull request!",
   "main": "update_nodes.js",
   "scripts": {
-    "start": "ts-node update_nodes.ts"
+    "start": "npx ts-node update_nodes.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@libsql/client": "^0.9.0",
+    "@libsql/client": "^0.8.0",
     "@prisma/adapter-libsql": "^5.18.0",
     "@prisma/client": "^5.18.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@libsql/client": "^0.8.0",
     "@prisma/adapter-libsql": "^5.18.0",
-    "@prisma/client": "^5.18.0"
+    "@prisma/client": "^5.18.0",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/node": "^22.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "target": "ESNext",
+      "module": "ESNext",
+      "moduleResolution": "node",
+      "strict": true,
+      "esModuleInterop": true,
+      "skipLibCheck": true
+    }
+  }
+  

--- a/update_nodes.ts
+++ b/update_nodes.ts
@@ -1,7 +1,7 @@
-import * as fs from 'fs';
-import { PrismaClient } from '@prisma/client';
-import { PrismaLibSQL } from "@prisma/adapter-libsql";
-import { createClient } from "@libsql/client";
+const fs = require('fs');
+const { PrismaClient } = require('@prisma/client');
+const { PrismaLibSQL } = require('@prisma/adapter-libsql');
+const { createClient } = require('@libsql/client');
 
 const libsql = createClient({
     url: process.env.TURSO_DATABASE_URL || '',

--- a/update_nodes.ts
+++ b/update_nodes.ts
@@ -2,6 +2,7 @@ const fs = require('fs');
 const { PrismaClient } = require('@prisma/client');
 const { PrismaLibSQL } = require('@prisma/adapter-libsql');
 const { createClient } = require('@libsql/client');
+require('dotenv').config();
 
 const libsql = createClient({
     url: process.env.TURSO_DATABASE_URL || '',


### PR DESCRIPTION
- Fix `SyntaxError: Cannot use import statement outside a module` with Update Nodes Workflow
- Fix libsql npm i conflict

Edit:
After the https://github.com/appujet/lavalink-list/pull/108/commits/9860c4e3955405dbc763c700f439539b432e42cf commit, it practically works - the script worked and removed the duplicate node, which can be seen in the commit, but locally there is an error
![image](https://github.com/user-attachments/assets/1025cf69-c62d-4b8c-a3ce-1f7ac9f36e29)

