### PR TITLE
Updated identifier credentials

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -225,7 +225,7 @@
         "authorId": "938443713527545966"
     },
     {
-        "identifier": "JaMusic LAVALINK",
+        "identifier": "JM Lite Entertainment",
         "host": "109.176.17.107",
         "port": 20003,
         "password": "jmlitelavalink",


### PR DESCRIPTION
Now supports only:
PH
Mixcloud
YouTube
YouTube Music
SoundCloud 
Spotify
TikTok 
Soundgasm 
Reddit
Deezer (being fixed internally)
Apple Music (adding soon)