### PR TITLE
Lavalink removed

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -223,14 +223,5 @@
         "secure": false,
         "restVersion": "v4",
         "authorId": "938443713527545966"
-    },
-    {
-        "identifier": "JaMusic LAVALINK",
-        "host": "109.176.17.107",
-        "port": 20003,
-        "password": "jmlitelavalink",
-        "secure": false,
-        "restVersion": "v4",
-        "authorId": "896607695329693746"
     }
 ]


### PR DESCRIPTION
Lavalink has been removed due to the hosting provider shutting down in February